### PR TITLE
Creating areas with bad size data.

### DIFF
--- a/lib/area/area-lib.js
+++ b/lib/area/area-lib.js
@@ -86,7 +86,7 @@ function AreaLib(client) {
         return new Promise(function(resolve, reject) {
             if (typeof(areaData.areacode) != 'undefined' && areaCode != areaData.areacode) {
                 reject(constants.errors.CREATE_AREACODE_NO_EXIST_IN_PAYLOAD);
-            } else if (typeof(areaData.size) === 'undefined') {
+            } else if (typeof(areaData.size) === 'undefined' || areaData.size !== 0) {
                 areaData.size = 0;
             }
 

--- a/test/area-async-test.js
+++ b/test/area-async-test.js
@@ -95,6 +95,19 @@ describe('The area-lib async module', function() {
                     }));
                 });
         });
+
+        it('Create area when size > 0 should set size to 0', function() {
+            var koboldValleyAreaSize5 = Object.assign({}, koboldValleyArea);
+            koboldValleyAreaSize5.size = 5;
+            return lib.area.async.createArea(koboldValleyAreaSize5.areacode, koboldValleyAreaSize5)
+                .then(function(success) {
+                    expect(success).to.equal(true);
+                    return client.hmgetAsync('AREAS:' + koboldValleyAreaSize5.areacode, 'size')
+                        .then(function(size) {
+                            parseInt(size, 10).should.equal(0);
+                        });
+                });
+        });
     });
 
     // R

--- a/test/area-test.js
+++ b/test/area-test.js
@@ -96,6 +96,19 @@ describe('The area-lib module', function() {
                 });
             });
         });
+
+        it('Create data for area with size > 0. Size should be 0.', function(done) {
+            var koboldValleyAreaSize5 = Object.assign({}, koboldValleyArea);
+            koboldValleyAreaSize5.size = 5;
+
+            lib.area.createArea(koboldValleyAreaSize5.areacode, koboldValleyAreaSize5, function(success) {
+                client.hmget('AREAS:' + koboldValleyAreaSize5.areacode, 'size', function(err, res) {
+                    expect(res).to.have.length(1);
+                    parseInt(res, 10).should.equal(0);
+                    done();
+                });
+            });
+        });
     });
 
     // R


### PR DESCRIPTION
When you create a new area, and the passed data object has a size member that is not zero, we will automatically set the size to zero.
This is a fix for an import/export bug.